### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Output
 The list of microsatellites is output in "scan" step. The MSI scoring step produces 4 files:
 
         output.prefix
-        output.prefix_dis_tab
+        output.prefix_dis
         output.prefix_germline
         output.prefix_somatic
 
@@ -122,7 +122,7 @@ The list of microsatellites is output in "scan" step. The MSI scoring step produ
         Total_Number_of_Sites   Number_of_Somatic_Sites %
         640     75      11.72
 
-3. output.prefix_dis_tab: read count distribution (N: normal; T: tumor)
+3. output.prefix_dis: read count distribution (N: normal; T: tumor)
 
         1       16248728        ACCTC   11      T       AAAGG   N       0       0       0       0       1       38      0       0       0       0       0       0       0
         1       16248728        ACCTC   11      T       AAAGG   T       0       0       0       0       17      22      1       0       0       0       0       0       0


### PR DESCRIPTION
README was set to <prefix>_dis_tab in May 2018 [[commit](https://github.com/ding-lab/msisensor/commit/290271a1e6d369d701f4dcbf08f87569aeea7369), then the sample.cpp was changed to output <prefix>_dis in June 2018 [[commit](https://github.com/ding-lab/msisensor/commit/38bc6549cd8ca119e562116897da6e529b3ed940)].